### PR TITLE
Allow Vercel frontend CORS

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ app = Flask(__name__)
 # === CORS pour autoriser le front Vercel ===
 ALLOWED_ORIGINS = [
     "https://greencard-fronted.vercel.app",
+    "https://greencard-frontend.vercel.app",
     "http://localhost:3000"  # gardé pour le développement local
 ]
 


### PR DESCRIPTION
## Summary
- allow greencard-frontend Vercel domain in CORS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b4709d144832fabe0f480ee033860