### PR TITLE
feat: secure api with role-based access and validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,14 +3,18 @@ from flask_cors import CORS
 from models import db
 import os
 from flask_jwt_extended import JWTManager
+from dotenv import load_dotenv
+import logging
+
+# === Chargement des variables d'environnement ===
+load_dotenv()
+logging.basicConfig(level=logging.INFO)
 
 # === Création de l'application ===
 app = Flask(__name__)
-# === CORS pour autoriser le front Vercel ===
+# === CORS pour autoriser uniquement le front Vercel ===
 ALLOWED_ORIGINS = [
-    "https://greencard-fronted.vercel.app",
-    "https://greencard-frontend.vercel.app",
-    "http://localhost:3000"  # gardé pour le développement local
+    "https://greencard-frontend.vercel.app"
 ]
 
 CORS(app, resources={
@@ -33,10 +37,14 @@ if not database_url:
 app.config["SQLALCHEMY_DATABASE_URI"] = database_url
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
-app.config['JWT_SECRET_KEY'] = os.environ.get('JWT_SECRET_KEY', 'dev-secret-key')  # Ajout pour JWT
-# Correction pour JWT: ajout du token location et du header name
-app.config['JWT_TOKEN_LOCATION'] = ['headers']
-app.config['JWT_HEADER_NAME'] = 'Authorization'
+jwt_secret = os.environ.get('JWT_SECRET_KEY')
+if not jwt_secret:
+    raise RuntimeError('JWT_SECRET_KEY not set')
+app.config['JWT_SECRET_KEY'] = jwt_secret
+# Utilisation d'un cookie sécurisé pour le token
+app.config['JWT_TOKEN_LOCATION'] = ['cookies']
+app.config['JWT_COOKIE_CSRF_PROTECT'] = True
+app.config['JWT_COOKIE_SECURE'] = True
 
 UPLOAD_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'uploads')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ flask==3.1.1
 flask-cors==6.0.0
 flask-sqlalchemy==3.1.1
 flask-jwt-extended
+python-dotenv
+cryptography
 blinker==1.9.0
 click==8.2.1
 greenlet==3.2.3

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -2,12 +2,18 @@
 from flask import Blueprint, request, jsonify
 from models import db, User, WithdrawalRequest
 from werkzeug.security import generate_password_hash, check_password_hash
-from flask_jwt_extended import create_access_token
+from flask_jwt_extended import (
+    create_access_token, jwt_required, get_jwt_identity, set_access_cookies
+)
+from utils.security import role_required, encrypt_data
+from utils.validators import is_valid_email, is_valid_iban, is_valid_bic
 
 auth_bp = Blueprint('auth', __name__)
 
 # Liste des demandes de virement (admin)
 @auth_bp.route('/withdrawals', methods=['GET'])
+@jwt_required()
+@role_required('admin')
 def list_withdrawal_requests():
     withdrawals = WithdrawalRequest.query.order_by(WithdrawalRequest.requested_at.desc()).all()
     result = []
@@ -15,13 +21,8 @@ def list_withdrawal_requests():
         user = User.query.get(w.user_id)
         result.append({
             'id': w.id,
-            'user_id': w.user_id,
             'producer_name': user.name if user else '',
-            'producer_email': user.email if user else '',
             'amount': w.amount,
-            'iban': w.iban,
-            'bic': w.bic,
-            'rib': w.rib,
             'status': w.status,
             'requested_at': w.requested_at.isoformat() if w.requested_at else ''
         })
@@ -29,6 +30,8 @@ def list_withdrawal_requests():
 
 # Suppression (validation) d'une demande de virement (admin)
 @auth_bp.route('/withdrawals/<int:withdrawal_id>', methods=['DELETE'])
+@jwt_required()
+@role_required('admin')
 def delete_withdrawal_request(withdrawal_id):
     withdrawal = WithdrawalRequest.query.get_or_404(withdrawal_id)
     db.session.delete(withdrawal)
@@ -37,23 +40,27 @@ def delete_withdrawal_request(withdrawal_id):
 
 # Demande de virement (producteur)
 @auth_bp.route('/withdrawals', methods=['POST'])
+@jwt_required()
+@role_required('producer')
 def create_withdrawal_request():
-    data = request.get_json()
-    user_id = data.get('user_id')
+    data = request.get_json() or {}
     amount = data.get('amount')
     iban = data.get('iban')
     bic = data.get('bic')
     rib = data.get('rib')
-    if not all([user_id, amount, iban]):
+    if not all([amount, iban]):
         return jsonify({'error': 'Champs requis manquants'}), 400
-    # Vérifie le solde du producteur
-    user = User.query.get(user_id)
-    if not user or user.role != 'producer':
-        return jsonify({'error': 'Utilisateur non trouvé ou non producteur'}), 404
+    if not is_valid_iban(iban) or (bic and not is_valid_bic(bic)):
+        return jsonify({'error': 'IBAN/BIC invalide'}), 400
     try:
         amount = float(amount)
+        if amount <= 0:
+            raise ValueError
     except Exception:
         return jsonify({'error': 'Montant invalide'}), 400
+    identity = get_jwt_identity()
+    user_id = identity['id'] if isinstance(identity, dict) else identity
+    user = User.query.get(user_id)
     if user.wallet_balance is None:
         user.wallet_balance = 0.0
     if amount > user.wallet_balance:
@@ -63,9 +70,9 @@ def create_withdrawal_request():
     withdrawal = WithdrawalRequest(
         user_id=user_id,
         amount=amount,
-        iban=iban,
-        bic=bic,
-        rib=rib
+        iban=encrypt_data(iban),
+        bic=encrypt_data(bic) if bic else None,
+        rib=encrypt_data(rib) if rib else None
     )
     db.session.add(withdrawal)
     db.session.commit()
@@ -82,6 +89,10 @@ def register():
 
     if not all([email, password, name, role]):
         return jsonify({'error': 'Champs requis manquants'}), 400
+    if not is_valid_email(email):
+        return jsonify({'error': 'Email invalide'}), 400
+    if role not in ['consumer', 'producer', 'admin']:
+        return jsonify({'error': 'Rôle invalide'}), 400
 
     if User.query.filter_by(email=email).first():
         return jsonify({'error': 'Utilisateur déjà existant'}), 409
@@ -95,7 +106,6 @@ def register():
         'message': 'Inscription réussie',
         'user': {
             'id': user.id,
-            'email': user.email,
             'name': user.name,
             'role': user.role
         }
@@ -113,15 +123,14 @@ def login():
     if not user or not check_password_hash(user.password, password):
         return jsonify({'error': 'Identifiants invalides'}), 401
 
-    # Générer le token JWT
+    # Générer le token JWT et le placer dans un cookie sécurisé
     token = create_access_token(identity={
         'id': user.id,
         'email': user.email,
         'name': user.name,
         'role': user.role
     })
-
-    return jsonify({
+    response = jsonify({
         'message': 'Connexion réussie',
         'user': {
             'id': user.id,
@@ -129,54 +138,62 @@ def login():
             'name': user.name,
             'role': user.role,
             'default_address': user.default_address
-        },
-        'token': token
-    }), 200
+        }
+    })
+    set_access_cookies(response, token)
+    return response, 200
 
 @auth_bp.route('/users', methods=['GET'])
+@jwt_required()
+@role_required('admin')
 def list_users():
     users = User.query.all()
     return jsonify([
         {
             'id': u.id,
-            'email': u.email,
             'name': u.name,
-            'role': u.role,
-            'wallet_balance': u.wallet_balance,
-            'default_address': u.default_address
+            'role': u.role
         }
         for u in users
     ])
 
 @auth_bp.route('/consumers', methods=['GET'])
+@jwt_required()
+@role_required('admin')
 def get_consumers():
     consumers = User.query.filter_by(role='consumer').all()
     return jsonify([{
         'id': u.id,
-        'email': u.email,
         'name': u.name,
         'registered_at': u.registered_at.isoformat()
     } for u in consumers]), 200
 
 @auth_bp.route('/users/<int:user_id>', methods=['PUT'])
+@jwt_required()
 def update_user_profile(user_id):
+    identity = get_jwt_identity()
+    if identity['id'] != user_id and identity.get('role') != 'admin':
+        return jsonify({'error': 'Forbidden'}), 403
     user = User.query.get_or_404(user_id)
     data = request.get_json()
     user.name = data.get('name', user.name)
     user.email = data.get('email', user.email)
-    # Ajoute ce champ si tu veux permettre l'adresse par défaut
     if hasattr(user, 'default_address'):
         user.default_address = data.get('default_address', getattr(user, 'default_address', None))
     db.session.commit()
     return jsonify({"message": "Profil mis à jour"}), 200
 
 @auth_bp.route('/users/<int:user_id>/password', methods=['PUT'])
+@jwt_required()
 def update_user_password(user_id):
+    identity = get_jwt_identity()
+    if identity['id'] != user_id and identity.get('role') != 'admin':
+        return jsonify({'error': 'Forbidden'}), 403
     user = User.query.get_or_404(user_id)
     data = request.get_json()
     new_password = data.get('password')
     if not new_password or len(new_password) < 6:
         return jsonify({"error": "Mot de passe trop court"}), 400
-    user.password = generate_password_hash(new_password)  # <-- Correction ici
+    user.password = generate_password_hash(new_password)
     db.session.commit()
     return jsonify({"message": "Mot de passe mis à jour"}), 200

--- a/routes/cart.py
+++ b/routes/cart.py
@@ -2,13 +2,16 @@
 from flask import Blueprint, request, jsonify
 from models import db, Cart, Product
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from utils.security import role_required
 
 cart_bp = Blueprint('cart', __name__)
 
 @cart_bp.route('/', methods=['GET'])
 @jwt_required()
+@role_required('consumer')
 def get_cart():
-    user_id = get_jwt_identity()
+    identity = get_jwt_identity()
+    user_id = identity['id'] if isinstance(identity, dict) else identity
     cart_items = Cart.query.filter_by(user_id=user_id).all()
     return jsonify([
         {
@@ -21,11 +24,15 @@ def get_cart():
 
 @cart_bp.route('/', methods=['POST'])
 @jwt_required()
+@role_required('consumer')
 def add_to_cart():
-    user_id = get_jwt_identity()
+    identity = get_jwt_identity()
+    user_id = identity['id'] if isinstance(identity, dict) else identity
     data = request.get_json()
     product_id = data.get("product_id")
     quantity = data.get("quantity", 1)
+    if quantity <= 0:
+        return jsonify({"error": "Quantité invalide"}), 400
 
     product = Product.query.get(product_id)
     if not product:
@@ -43,8 +50,10 @@ def add_to_cart():
 
 @cart_bp.route('/<int:product_id>', methods=['DELETE'])
 @jwt_required()
+@role_required('consumer')
 def remove_from_cart(product_id):
-    user_id = get_jwt_identity()
+    identity = get_jwt_identity()
+    user_id = identity['id'] if isinstance(identity, dict) else identity
     item = Cart.query.filter_by(user_id=user_id, product_id=product_id).first()
     if item:
         db.session.delete(item)

--- a/routes/newsletter.py
+++ b/routes/newsletter.py
@@ -1,13 +1,16 @@
 from flask import Blueprint, request, jsonify
 from models import db, NewsletterSubscriber
+from flask_jwt_extended import jwt_required
+from utils.security import role_required
+from utils.validators import is_valid_email
 
 newsletter_bp = Blueprint('newsletter', __name__)
 
 @newsletter_bp.route('/subscribe', methods=['POST'])
 def subscribe():
     email = request.get_json().get('email')
-    if not email:
-        return jsonify({'error': 'Email requis'}), 400
+    if not email or not is_valid_email(email):
+        return jsonify({'error': 'Email invalide'}), 400
     if NewsletterSubscriber.query.filter_by(email=email).first():
         return jsonify({'error': 'Déjà inscrit'}), 409
     db.session.add(NewsletterSubscriber(email=email))
@@ -15,7 +18,11 @@ def subscribe():
     return jsonify({'message': 'Inscription réussie'}), 201
 
 @newsletter_bp.route('/list', methods=['GET'])
+@jwt_required()
+@role_required('admin')
 def list_subscribers():
-    from models import NewsletterSubscriber
     subs = NewsletterSubscriber.query.all()
-    return jsonify([s.email for s in subs])
+    def mask(email):
+        name, domain = email.split('@')
+        return name[0] + "***@" + domain
+    return jsonify([mask(s.email) for s in subs])

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+from cryptography.fernet import Fernet
+
+# Set env variables before importing app
+os.environ.setdefault('JWT_SECRET_KEY', 'test-secret')
+os.environ.setdefault('ENCRYPTION_KEY', Fernet.generate_key().decode())
+
+from app import app, db
+from models import User
+
+@pytest.fixture
+def client():
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        JWT_COOKIE_SECURE=False,
+        JWT_COOKIE_CSRF_PROTECT=False
+    )
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        admin = User(email='admin@example.com', password=generate_password_hash('pass'), name='Admin', role='admin')
+        prod = User(email='prod@example.com', password=generate_password_hash('pass'), name='Prod', role='producer')
+        db.session.add_all([admin, prod])
+        db.session.commit()
+    with app.test_client() as client:
+        yield client
+
+
+def login(client, email, password='pass'):
+    return client.post('/api/auth/login', json={'email': email, 'password': password})
+
+
+def test_users_requires_auth(client):
+    res = client.get('/api/auth/users')
+    assert res.status_code == 401
+
+
+def test_producer_cannot_access_users(client):
+    login(client, 'prod@example.com')
+    res = client.get('/api/auth/users')
+    assert res.status_code == 403
+
+
+def test_admin_can_access_users(client):
+    login(client, 'admin@example.com')
+    res = client.get('/api/auth/users')
+    assert res.status_code == 200
+    assert all('email' not in u for u in res.get_json())

--- a/utils/security.py
+++ b/utils/security.py
@@ -1,0 +1,42 @@
+import os
+from functools import wraps
+from flask import jsonify
+from flask_jwt_extended import get_jwt_identity
+from cryptography.fernet import Fernet
+import logging
+
+logger = logging.getLogger(__name__)
+
+# --- Role based access decorator ---
+def role_required(*roles):
+    def wrapper(fn):
+        @wraps(fn)
+        def decorator(*args, **kwargs):
+            identity = get_jwt_identity()
+            user_role = None
+            if isinstance(identity, dict):
+                user_role = identity.get('role')
+            if user_role not in roles:
+                logger.warning("Unauthorized access attempt for role %s", user_role)
+                return jsonify({'error': 'Forbidden'}), 403
+            return fn(*args, **kwargs)
+        return decorator
+    return wrapper
+
+# --- Encryption utilities ---
+_encryption_key = os.environ.get('ENCRYPTION_KEY')
+if _encryption_key is None:
+    # In production, this should be strictly provided
+    _encryption_key = Fernet.generate_key()
+    logger.warning("ENCRYPTION_KEY not set; generated temporary key")
+_cipher = Fernet(_encryption_key)
+
+def encrypt_data(data: str) -> str:
+    if data is None:
+        return None
+    return _cipher.encrypt(data.encode()).decode()
+
+def decrypt_data(token: str) -> str:
+    if token is None:
+        return None
+    return _cipher.decrypt(token.encode()).decode()

--- a/utils/validators.py
+++ b/utils/validators.py
@@ -1,0 +1,17 @@
+import re
+
+EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+IBAN_REGEX = re.compile(r"^[A-Z]{2}[0-9A-Z]{13,32}$")
+BIC_REGEX = re.compile(r"^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$")
+
+
+def is_valid_email(email: str) -> bool:
+    return bool(email and EMAIL_REGEX.match(email))
+
+
+def is_valid_iban(iban: str) -> bool:
+    return bool(iban and IBAN_REGEX.match(iban.replace(' ', '').upper()))
+
+
+def is_valid_bic(bic: str) -> bool:
+    return bool(bic and BIC_REGEX.match(bic.upper()))


### PR DESCRIPTION
## Summary
- add role-based decorator and data encryption utilities
- secure auth, cart and newsletter routes with JWT cookies and role checks
- validate inputs and restrict exposed fields; add authorization tests

## Testing
- `python -m py_compile app.py routes/auth.py routes/cart.py routes/newsletter.py utils/security.py utils/validators.py tests/test_authorization.py`
- `pytest -q` *(fails: No module named 'cryptography')*


------
https://chatgpt.com/codex/tasks/task_e_689c57fd68e4832fb5f992a954f40b16