### PR TITLE
Handle routes with and without trailing slash

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ from flask_jwt_extended import JWTManager
 
 # === Création de l'application ===
 app = Flask(__name__)
+# Permet de gérer les routes avec et sans slash final
+app.url_map.strict_slashes = False
 # === CORS pour autoriser le front Vercel ===
 ALLOWED_ORIGINS = os.environ.get(
     "ALLOWED_ORIGINS",


### PR DESCRIPTION
## Summary
- Handle routes with and without trailing slash by disabling strict slash checking

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689c688bfa9c832fa6a2bec27d5001e1